### PR TITLE
fixing the docs on info

### DIFF
--- a/plugins/modules/ec2_transit_gateway_vpc_attachment_info.py
+++ b/plugins/modules/ec2_transit_gateway_vpc_attachment_info.py
@@ -49,18 +49,15 @@ extends_documentation_fragment:
 EXAMPLES = '''
 # Describe a specific Transit Gateway attachment.
 - community.aws.ec2_transit_gateway_vpc_attachment_info:
-    state: present
     id: 'tgw-attach-0123456789abcdef0'
 
 # Describe all attachments attached to a transit gateway.
 - community.aws.ec2_transit_gateway_vpc_attachment_info:
-    state: present
     filters:
       transit-gateway-id: tgw-0fedcba9876543210'
 
 # Describe all attachments in an account.
 - community.aws.ec2_transit_gateway_vpc_attachment_info:
-    state: present
     filters:
       transit-gateway-id: tgw-0fedcba9876543210'
 '''


### PR DESCRIPTION
using the with `state: present` results in this error: ` "Unsupported parameters for (community.aws.ec2_transit_gateway_vpc_attachment_info) module: state. Supported parameters include: access_key, aws_ca_bundle, aws_config, debug_botocore_endpoint_logs, endpoint_url, filters, id, include_deleted, name, profile, region, secret_key, session_token, validate_certs (access_token, attachment_id, aws_access_key, aws_access_key_id, aws_endpoint_url, aws_profile, aws_region, aws_secret_access_key, aws_secret_key, aws_security_token, aws_session_token, ec2_access_key, ec2_region, ec2_secret_key, ec2_url, s3_url, security_token)."`